### PR TITLE
Replace deprecated numpy aliases in normalization

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -3,18 +3,17 @@ import math
 import os
 import pickle
 
+import dash
+import dash_core_components as dcc
+import dash_html_components as html
 import numpy as np
 import pandas as pd
 import plotly.graph_objs as go
 import requests
-from sklearn.preprocessing import StandardScaler
-from xgboost import XGBClassifier
-
-import dash
-import dash_core_components as dcc
-import dash_html_components as html
 import search_google.api
 from dash.dependencies import Input, Output, State
+from sklearn.preprocessing import StandardScaler
+from xgboost import XGBClassifier
 
 GOOGLE_API_DEVELOPER_KEY = "enter_key_here"
 CSE_ID = "enter_id_here"
@@ -50,7 +49,7 @@ df_weight_classes = {
 
 
 def normalize(df: pd.DataFrame, scaler) -> pd.DataFrame:
-    df_num = df.select_dtypes(include=[np.float, np.int])
+    df_num = df.select_dtypes(include=[np.number])
     df[list(df_num.columns)] = scaler.transform(df[list(df_num.columns)])
     return df
 


### PR DESCRIPTION
## Summary
- replace deprecated `np.float` and `np.int` with `np.number` in `normalize`
- sort imports via isort

## Testing
- `isort src/app/app.py`
- `black src/app/app.py`
- `pre-commit run --files src/app/app.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acdce2f23c8330b079b18efc09cf2d