### PR TITLE
Handle non-string strike stats in preprocessing

### DIFF
--- a/src/createdata/preprocess.py
+++ b/src/createdata/preprocess.py
@@ -111,12 +111,32 @@ class Preprocessor:
         attempt_suffix = "_att"
         landed_suffix = "_landed"
 
+        def _extract_attempts(value):
+            if isinstance(value, str) and "of" in value:
+                try:
+                    return int(value.split("of")[1])
+                except (IndexError, ValueError):
+                    return 0
+            if pd.isna(value):
+                return 0
+            return int(value)
+
+        def _extract_landed(value):
+            if isinstance(value, str) and "of" in value:
+                try:
+                    return int(value.split("of")[0])
+                except (IndexError, ValueError):
+                    return 0
+            if pd.isna(value):
+                return 0
+            return int(value)
+
         for column in columns:
             self.fights[column + attempt_suffix] = self.fights[column].apply(
-                lambda X: int(X.split("of")[1])
+                _extract_attempts
             )
             self.fights[column + landed_suffix] = self.fights[column].apply(
-                lambda X: int(X.split("of")[0])
+                _extract_landed
             )
 
         self.fights.drop(columns, axis=1, inplace=True)


### PR DESCRIPTION
## Summary
- guard against non-string values in fight stat columns by extracting attempts and landed totals safely

## Testing
- `python -m src.create_ufc_data` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests==2.23.0)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbaa02cd483309026399f3a7e1884