### PR TITLE
Remove Open Weight mapping

### DIFF
--- a/src/app/app.py
+++ b/src/app/app.py
@@ -44,7 +44,6 @@ df_weight_classes = {
     "Women's Bantamweight": "weight_class_Women_Bantamweight",
     "Women's Featherweight": "weight_class_Women_Featherweight",
     "Catch Weight": "weight_class_CatchWeight",
-    "Open Weight": "weight_class_OpenWeight",
 }
 
 


### PR DESCRIPTION
## Summary
- drop unused `Open Weight` entry from `df_weight_classes`
- confirmed no code depends on `weight_class_OpenWeight`

## Testing
- `python -m py_compile src/app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68acf82755488330b452161d8cabf13d